### PR TITLE
update node-docker for mrcide

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-stretch
+FROM node:14-bullseye
 
 # Install docker
 RUN apt-get update
@@ -14,4 +14,4 @@ RUN add-apt-repository \
    $(lsb_release -cs) \
    stable"
 RUN apt-get update
-RUN apt-get install -y docker-ce=5:18.09.0~3-0~debian-stretch
+RUN apt-get install docker-ce -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.1.0
+node:14-stretch
 
 # Install docker
 RUN apt-get update

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-bullseye
+FROM node:14.21-bullseye
 
 # Install docker
 RUN apt-get update

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM node:12-stretch
+FROM node:14-bullseye
 
 # Install docker
 RUN apt-get update
 RUN apt-get install -y \
         apt-transport-https \
+        gnupg2 \
         ca-certificates \
         curl \
         software-properties-common
@@ -13,4 +14,4 @@ RUN add-apt-repository \
    $(lsb_release -cs) \
    stable"
 RUN apt-get update
-RUN apt-get install -y docker-ce=5:18.09.0~3-0~debian-stretch
+RUN apt-get install docker-ce -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.21-bullseye
+FROM node:14.1.0
 
 # Install docker
 RUN apt-get update

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-node:14-stretch
+FROM node:14-stretch
 
 # Install docker
 RUN apt-get update
@@ -14,4 +14,4 @@ RUN add-apt-repository \
    $(lsb_release -cs) \
    stable"
 RUN apt-get update
-RUN apt-get install docker-ce -y
+RUN apt-get install -y docker-ce=5:18.09.0~3-0~debian-stretch

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2021 Imperial College of Science, Technology and Medicine
+Copyright (c) 2022 Imperial College of Science, Technology and Medicine
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # node-docker
-Contains a docker file for an image based on `node-12` with docker installed, and script to build, tag and push
-the image to the vimc docker hub.
+Contains a docker file for an image based on `node-14` with docker installed, and script to build, tag and push
+the image to the mrcide docker hub.
 
 ## building
 Run `./build-image.sh` to build and push to docker hub. This script is also run on BuildKite.
 
 ## usage
-This image is used by [Montagu-Webapps](https://github.com/vimc/montagu-webapps) 
-and [Montagu-Proxy](https://github.com/vimc/montagu-proxy)
+This image is used by [Montagu-Webapps](https://github.com/mrc-ide/hint)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # node-docker
 Contains a docker file for an image based on `node-14` with docker installed, and script to build, tag and push
-the image to the mrcide docker hub.
+the image to the mrcide docker hub. 
+
+This project was forked from https://github.com/vimc/node-docker
 
 ## building
 Run `./build-image.sh` to build and push to docker hub. This script is also run on BuildKite.
 
 ## usage
-This image is used by [Montagu-Webapps](https://github.com/mrc-ide/hint)
+This image is used by [HINT](https://github.com/mrc-ide/hint)

--- a/build-image.sh
+++ b/build-image.sh
@@ -13,7 +13,7 @@ else
     GIT_BRANCH=$(git symbolic-ref --short HEAD)
 fi
 
-ORG=vimc
+ORG=mrcide
 NAME=node-docker
 
 APP_DOCKER_COMMIT_TAG=${ORG}/${NAME}:${GIT_ID}


### PR DESCRIPTION
This PR forks node-docker from vimc to mrcide as hint has moved to node 14.